### PR TITLE
Add Nexus upload step to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,3 +55,15 @@ jobs:
               removeArtifacts: true
               replacesArtifacts: true
               artifacts: StealthAndCombatTweaks-${{ github.ref_name }}.zip
+          
+          - name: Upload to Nexus
+            uses: hmlendea/nexusmods-update@latest
+            with:
+              account_email_address: ${{ secrets.NEXUS_UPLOADER_USERNAME }}
+              account_password: ${{ secrets.NEXUS_UPLOADER_PASSWORD }}
+              nexus_game_id: "starfield"
+              nexus_mod_id: "5785"
+              mod_file_name: "Stealth and Combat Tweaks ${{ github.ref_name }}"
+              mod_version: ${{ github.ref_name }}
+              file_description: "Changelog: https://github.com/0xDezzy/Stealth-and-Combat-Tweaks/releases/tag/${{ github.ref_name }}"
+              file_path: "${{ github.workspace }}/StealthAndCombatTweaks-${{ github.ref_name }}.zip"


### PR DESCRIPTION
This commit adds a new step to the release workflow that uploads the mod file to Nexusmods. The Nexus uploader action is used with the provided account credentials and mod details such as game ID, mod ID, file name, version, description, and file path. The changelog URL is also included in the file description.